### PR TITLE
fix notifications

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -42,19 +42,24 @@ const NotificationList = () => {
             message={n.message}
             description={n.description}
             txid={n.txid}
+            onHide={() => {
+              setNotificationStore((state: any) => {
+                const reversedIndex = reversedNotifications.length - 1 - idx;
+                state.notifications = [
+                  ...notifications.slice(0, reversedIndex),
+                  ...notifications.slice(reversedIndex + 1),
+                ];
+              });
+            }}
           />
         ))}
       </div>
     </div>
-  )
+  );
 }
 
-const Notification = ({ type, message, description, txid }) => {
+const Notification = ({ type, message, description, txid, onHide }) => {
   const { connection } = useConnection();
-
-  const [showNotification, setShowNotification] = useState(true)
-
-  if (!showNotification) return null;
 
   // TODO: we dont have access to the network or endpoint here.. 
   // getExplorerUrl(connection., txid, 'tx')
@@ -100,7 +105,7 @@ const Notification = ({ type, message, description, txid }) => {
           </div>
           <div className={`ml-4 flex-shrink-0 self-start flex`}>
             <button
-              onClick={() => setShowNotification(false)}
+              onClick={() => onHide()}
               className={`bg-bkg-2 default-transition rounded-md inline-flex text-fgd-3 hover:text-fgd-4 focus:outline-none`}
             >
               <span className={`sr-only`}>Close</span>

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -14,20 +14,6 @@ const NotificationList = () => {
     (s) => s
   )
 
-  useEffect(() => {
-    if (notifications.length > 0) {
-      const id = setInterval(() => {
-        setNotificationStore((state: any) => {
-          state.notifications = notifications.slice(1, notifications.length)
-        })
-      }, 8000)
-
-      return () => {
-        clearInterval(id)
-      }
-    }
-  }, [notifications, setNotificationStore])
-
   const reversedNotifications = [...notifications].reverse()
 
   return (
@@ -64,6 +50,17 @@ const Notification = ({ type, message, description, txid, onHide }) => {
   // TODO: we dont have access to the network or endpoint here.. 
   // getExplorerUrl(connection., txid, 'tx')
   // Either a provider, context, and or wallet adapter related pro/contx need updated
+
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      onHide()
+    }, 8000);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [onHide]);
 
   return (
     <div


### PR DESCRIPTION
This PR fixes an issue with notifications where clicking the hide button doesn't hide the notification permanently

## Steps to reproduce

1. Navigate to basics page
2. Click sign message
3. Approve transaction
4. Click X to close notification
5. Click sign message
6. Reject transaction
7. The first notification that was previously closed has appeared again

## Changes

Previously there was a state variable within the notification that would remember if it was hidden. The change was to replace that with a call to the notification store. Also the timer for auto hiding the notification is now held inside the notification element, and not the container, so each one will keep track of its own time and hide itself

